### PR TITLE
Update devices.json with 2018 new models

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -165,6 +165,26 @@
           "name": "X",
           "type": "GSM+CDMA"
         }
+      },
+      {
+        "iPhone11,2": {
+          "name": "XS"
+        }
+      },
+      {
+        "iPhone11,4": {
+          "name": "XS Max"
+        }
+      },
+      {
+        "iPhone11,6": {
+          "name": "XS Max"
+        }
+      },
+      {
+        "iPhone11,8": {
+          "name": "XR"
+        }
       }
     ],
     "iPad": [


### PR DESCRIPTION
Info from https://www.theiphonewiki.com/wiki/Models and https://gist.github.com/adamawolf/3048717. The second XS Max model is the dual sim model for China